### PR TITLE
Add cleanup on KeyboardInterrupt

### DIFF
--- a/example.py
+++ b/example.py
@@ -105,7 +105,7 @@ except KeyboardInterrupt:
     for i in range(nmotes):
         wiiuse.set_leds(wiimotes[i], 0)
         wiiuse.rumble(wiimotes[i], 0)
-        wiiuse.disconnect(wiimotes[i])
+    wiiuse.cleanup(wiimotes, nmotes)
 
 print('done')
 

--- a/wiiuse/__init__.py
+++ b/wiiuse/__init__.py
@@ -373,11 +373,12 @@ def init(nwiimotes):
     # wapi = wiiuse_api[0]
 
     # initialize our other function pointers
-    global find, connect, set_leds, rumble, status, poll, disconnect, motion_sensing
+    global find, connect, cleanup, set_leds, rumble, status, poll, disconnect, motion_sensing
     global set_ir, toggle_rumble, set_ir_vres, set_ir_position, set_aspect_ratio
     global set_orient_threshold, set_flags
     find = dll.wiiuse_find
     connect = dll.wiiuse_connect
+    cleanup = dll.wiiuse_cleanup
     set_leds = dll.wiiuse_set_leds
     rumble = dll.wiiuse_rumble
     status = dll.wiiuse_status


### PR DESCRIPTION
I encountered an issue where event details were not showing on subsequent runs of the example.  I fixed it by adding a call to `wiiuse_cleanup` at the end of the example to match the wiiuse example.  